### PR TITLE
alien_invasion: add exit shortcut button

### DIFF
--- a/alien_invasion/game_functions.py
+++ b/alien_invasion/game_functions.py
@@ -11,6 +11,8 @@ def check_keydown_events(event, ai_settings, screen, ship, bullets):
 		ship.moving_left = True
 	elif event.key == pygame.K_SPACE:
 		fire_bullet(ai_settings, screen, ship, bullets)
+	elif event.key == pygame.K_q:
+		sys.exit()
 
 def fire_bullet(ai_settings, screen, ship, bullets):
 	"""Fire a bullet if limit not reached yet"""


### PR DESCRIPTION
Ends the game when `Q` is pressed. This is quite safe because the `Q` key is far from the arrow keys and the spacebar which are used as main navigation keys, so it is unlikely a player will accidentally press `Q` and quit the game. This closes #12.